### PR TITLE
fix: remove rollup warning & separate directives for each output chunk

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,14 +40,7 @@ export default function swcPreserveDirectivePlugin(): Plugin {
 
       /**
        * @swc/core's node span doesn't start with 0
-       * Although the behavior is not intended, the swc team won't fix it since swc.parse
-       * will be deprecated in the future anyway.
-       *
-       * See https://github.com/swc-project/swc/issues/1366
-       *
-       * For now, let's just use the `Module.span.start` as the offset to fix the span
-       *
-       * FIXME: migrate to rollup built-in acorn based parser (this.parse)
+       * https://github.com/swc-project/swc/issues/1366
        */
       const { body, interpreter, span: { start: offset } } = await parse(code, parseOptions)
 

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -17,8 +17,7 @@ export { bar, baz, foo };
 
 exports[`preserve-directive (rollup 3) should output separate directive for multiple output chunk 1`] = `
 {
-  "client": "'use server';
-'use client';
+  "client": "'use client';
 'use sukka';
 import { useState } from 'react';
 
@@ -32,8 +31,6 @@ const ClientComponent = ()=>{
 export { ClientComponent, foo };
 ",
   "server": "'use server';
-'use client';
-'use sukka';
 import { readFile } from 'fs/promises';
 
 const ServerComponent = async ()=>{


### PR DESCRIPTION
The PR does 2 things:

- Each output chunk will only have its separate directives.
  - This allows the server/client builds with different input entries to have correct directives.
- Avoid rollup warnings about module-level directives.
  <img width="1587" alt="image" src="https://github.com/huozhi/rollup-plugin-swc-preserve-directives/assets/40715044/44e71d0c-f592-4aef-bd14-41e3fdcd01ef">
