### PR TITLE
feat: add rollup 2 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@swc/core": ">=1.2.165",
-    "rollup": "^3.0.0"
+    "rollup": "^2.0.0 || ^3.0.0"
   },
   "dependencies": {
     "@napi-rs/magic-string": "^0.3.4"
@@ -46,6 +46,7 @@
     "jest": "^29.6.1",
     "rollup": "^3.26.2",
     "rollup-plugin-swc3": "^0.9.0",
+    "rollup2": "npm:rollup@^2.79.1",
     "typescript": "^5.1.6"
   },
   "packageManager": "pnpm@7.24.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ specifiers:
   jest: ^29.6.1
   rollup: ^3.26.2
   rollup-plugin-swc3: ^0.9.0
+  rollup2: npm:rollup@^2.79.1
   typescript: ^5.1.6
 
 dependencies:
@@ -26,6 +27,7 @@ devDependencies:
   jest: 29.6.1_@types+node@20.4.1
   rollup: 3.26.2
   rollup-plugin-swc3: 0.9.0_lvywkpsbewqmirs3gigiq5kd2q
+  rollup2: /rollup/2.79.1
   typescript: 5.1.6
 
 packages:
@@ -2589,6 +2591,14 @@ packages:
       '@swc/core': 1.3.68_@swc+helpers@0.5.1
       get-tsconfig: 4.6.2
       rollup: 3.26.2
+    dev: true
+
+  /rollup/2.79.1:
+    resolution: {integrity: sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /rollup/3.20.7:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from 'rollup'
+import type { Plugin, RenderedChunk } from 'rollup'
 import { extname } from 'path'
 import { parse } from '@swc/core'
 import { MagicString } from '@napi-rs/magic-string'
@@ -71,7 +71,15 @@ export default function swcPreserveDirectivePlugin(): Plugin {
     },
 
     renderChunk(code, chunk, { sourcemap }) {
-      const outputDirectives = chunk.moduleIds
+      /**
+       * chunk.moduleIds is introduced in rollup 3
+       * Add a fallback for rollup 2
+       */
+      const moduleIds = 'moduleIds' in chunk
+        ? chunk.moduleIds
+        : Object.keys((chunk as RenderedChunk).modules)
+
+      const outputDirectives = moduleIds
         .map((id) => {
           if (meta.directives[id]) {
             return meta.directives[id];

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1,5 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`preserve-directive (rollup 2) should merge duplicated directives 1`] = `
+{
+  "index": "'use client';
+'use sukka';
+const foo = 'foo';
+
+const bar = 'bar';
+
+const baz = 'baz';
+
+export { bar, baz, foo };
+",
+}
+`;
+
+exports[`preserve-directive (rollup 2) should output separate directive for multiple output chunk 1`] = `
+{
+  "client": "'use client';
+'use sukka';
+import { useState } from 'react';
+
+const foo = 'is-client';
+
+const ClientComponent = ()=>{
+    const [count] = useState(0);
+    return /*#__PURE__*/ React.createElement("div", null, "count: ", count);
+};
+
+export { ClientComponent, foo };
+",
+  "server": "'use server';
+import { readFile } from 'fs/promises';
+
+const ServerComponent = async ()=>{
+    const foo = await readFile('__virtual_data/foo.txt', 'utf8');
+    return /*#__PURE__*/ React.createElement("div", null, foo);
+};
+
+export { ServerComponent };
+",
+}
+`;
+
+exports[`preserve-directive (rollup 2) should preserve directives 1`] = `
+{
+  "index": "'use client';
+import { useState } from 'react';
+
+function client() {
+    return useState(null);
+}
+
+export { client as default };
+",
+}
+`;
+
+exports[`preserve-directive (rollup 2) should preserve shebang 1`] = `
+{
+  "index": "#!/usr/bin/env node
+console.log('shebang');
+",
+}
+`;
+
 exports[`preserve-directive (rollup 3) should merge duplicated directives 1`] = `
 {
   "index": "'use client';

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,8 @@
 import { tester } from './testing-utils';
-import { rollup } from 'rollup';
+import { rollup as rollup3 } from 'rollup';
+import { rollup as rollup2 } from 'rollup2';
 
-const tests = (rollupImpl: typeof rollup) => {
+const tests = (rollupImpl: typeof rollup3) => {
   it('should preserve shebang', async () => {
     const output = await tester(rollupImpl, {
       input: 'shebang/index.ts'
@@ -39,7 +40,12 @@ const tests = (rollupImpl: typeof rollup) => {
 }
 
 describe('preserve-directive (rollup 3)', () => {
-  tests(rollup);
+  tests(rollup3);
+});
+
+describe('preserve-directive (rollup 2)', () => {
+  // @ts-expect-error -- rollup 2 type is imcompatible w/ rollup 3
+  tests(rollup2);
 });
 
 // TODO: add test case for rollup 2

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -47,5 +47,3 @@ describe('preserve-directive (rollup 2)', () => {
   // @ts-expect-error -- rollup 2 type is imcompatible w/ rollup 3
   tests(rollup2);
 });
-
-// TODO: add test case for rollup 2


### PR DESCRIPTION
[rollup-plugin-swc3](https://github.com/SukkaW/rollup-plugin-swc) supports both rollup 2 and rollup 3, and I want to re-export `rollup-plugin-swc-preserve-directives` from `rollup-plugin-swc3` without introducing a breaking change.

The PR does 3 things:

- Fix rollup 2 compatibility
  - `RenderedChunk['moduleIds']` is introduced in rollup 3
- Add rollup 2 tests
- Add rollup 2 to the `peerDependencies` field.