### PR TITLE
chore: add both default and named export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ interface PreserveDirectiveMeta {
   directives: Record<string, Set<string>>
 }
 
-export default function swcPreserveDirectivePlugin(): Plugin {
+export function swcPreserveDirective(): Plugin {
   const meta: PreserveDirectiveMeta = {
     shebang: null,
     directives: {},
@@ -103,3 +103,5 @@ export default function swcPreserveDirectivePlugin(): Plugin {
     }
   }
 }
+
+export default swcPreserveDirective


### PR DESCRIPTION
The default export breaks `rollup -c rollup.config.ts --configPlugin swc3 --bundleConfigAsCjs`.

The PR adds both named export and default export.