### PR TITLE
chore(build): make output esm filename with `.mjs` ext

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Rollup plugin to preserve directives with SWC",
   "types": "./dist/index.d.ts",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
+  "module": "./dist/es/index.mjs",
   "exports": {
     "types": "./dist/index.d.ts",
-    "import": "./dist/es/index.js",
+    "import": "./dist/es/index.mjs",
     "default": "./dist/cjs/index.js"
   },
   "files": [


### PR DESCRIPTION
Fixes https://github.com/SukkaW/rollup-plugin-swc/issues/39.

It seems that Rollup is mistakenly treating `rollup-plugin-swc-preserve-directives/dist/es/index.js` as a CJS module, even though it's specified as an ESM module in the `package.json`.

In this PR, I change the `./dist/es/index.js` to `./dist/es/index.mjs` which may help Rollup correctly recognize and treat the file as an ESM module.

After the PR, the bunchee will output `./dist/es/index.mjs` instead of `./dist/es/index.js`.