### PR TITLE
Revert "refactor: replace swc with acorn" and remove code deleting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ A rollup plugin helps preserving shebang and string directives in your code.
 
 ```bash
 npm install rollup-swc-preserve-directives
+
+# You also need to install @swc/core as peer dependency
+npm install @swc/core
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -30,13 +30,14 @@
   "author": "huozhi",
   "license": "MIT",
   "peerDependencies": {
+    "@swc/core": ">=1.3.79",
     "rollup": "^2.0.0 || ^3.0.0"
   },
   "dependencies": {
     "@napi-rs/magic-string": "^0.3.4"
   },
   "devDependencies": {
-    "@swc/core": "^1.3.68",
+    "@swc/core": "^1.3.82",
     "@swc/helpers": "^0.5.1",
     "@swc/jest": "^0.2.26",
     "@types/estree": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "acorn": "^8.10.0",
     "bunchee": "^3.6.1",
     "jest": "^29.6.1",
-    "rollup": "^3.26.2",
+    "rollup": "^3.28.1",
     "rollup-plugin-swc3": "^0.9.0",
     "rollup2": "npm:rollup@^2.79.1",
     "typescript": "^5.1.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ specifiers:
   acorn: ^8.10.0
   bunchee: ^3.6.1
   jest: ^29.6.1
-  rollup: ^3.26.2
+  rollup: ^3.28.1
   rollup-plugin-swc3: ^0.9.0
   rollup2: npm:rollup@^2.79.1
   typescript: ^5.1.6
@@ -29,8 +29,8 @@ devDependencies:
   acorn: 8.10.0
   bunchee: 3.6.1_typescript@5.1.6
   jest: 29.6.1_@types+node@20.4.1
-  rollup: 3.26.2
-  rollup-plugin-swc3: 0.9.0_iw3jk5lyrkr3mh5xkkw6sbmnnu
+  rollup: 3.28.1
+  rollup-plugin-swc3: 0.9.0_ayu62oiofpgomvef3ep6kxzqem
   rollup2: /rollup/2.79.1
   typescript: 5.1.6
 
@@ -2593,7 +2593,7 @@ packages:
       rollup: 3.20.7
     dev: true
 
-  /rollup-plugin-swc3/0.9.0_iw3jk5lyrkr3mh5xkkw6sbmnnu:
+  /rollup-plugin-swc3/0.9.0_ayu62oiofpgomvef3ep6kxzqem:
     resolution: {integrity: sha512-b5OjzeD9F5H6hmtHqI6GJkPiJPyUrIu9cjvvjv4OOMW79nukmmd8QJLqrVxsJk7Y3vZXOzOgBSzKLkCM/Jt5Vw==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -2605,7 +2605,7 @@ packages:
       '@rollup/pluginutils': 4.2.1
       '@swc/core': 1.3.82_@swc+helpers@0.5.1
       get-tsconfig: 4.6.2
-      rollup: 3.26.2
+      rollup: 3.28.1
     dev: true
 
   /rollup-swc-preserve-directives/0.3.2_uwjsx23hxuosdqu2kkre7rtzqq:
@@ -2635,8 +2635,8 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /rollup/3.26.2:
-    resolution: {integrity: sha512-6umBIGVz93er97pMgQO08LuH3m6PUb3jlDUUGFsNJB6VgTCUaDFpupf5JfU30529m/UKOgmiX+uY6Sx8cOYpLA==}
+  /rollup/3.28.1:
+    resolution: {integrity: sha512-R9OMQmIHJm9znrU3m3cpE8uhN0fGdXiawME7aZIpQqvpS/85+Vt1Hq1/yVIcYfOmaQiHjvXkQAoJukvLpau6Yw==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@napi-rs/magic-string': ^0.3.4
-  '@swc/core': ^1.3.68
+  '@swc/core': ^1.3.82
   '@swc/helpers': ^0.5.1
   '@swc/jest': ^0.2.26
   '@types/estree': ^1.0.1
@@ -20,9 +20,9 @@ dependencies:
   '@napi-rs/magic-string': 0.3.4
 
 devDependencies:
-  '@swc/core': 1.3.68_@swc+helpers@0.5.1
+  '@swc/core': 1.3.82_@swc+helpers@0.5.1
   '@swc/helpers': 0.5.1
-  '@swc/jest': 0.2.26_@swc+core@1.3.68
+  '@swc/jest': 0.2.26_@swc+core@1.3.82
   '@types/estree': 1.0.1
   '@types/jest': 29.5.2
   '@types/node': 20.4.1
@@ -30,7 +30,7 @@ devDependencies:
   bunchee: 3.6.1_typescript@5.1.6
   jest: 29.6.1_@types+node@20.4.1
   rollup: 3.26.2
-  rollup-plugin-swc3: 0.9.0_lvywkpsbewqmirs3gigiq5kd2q
+  rollup-plugin-swc3: 0.9.0_iw3jk5lyrkr3mh5xkkw6sbmnnu
   rollup2: /rollup/2.79.1
   typescript: 5.1.6
 
@@ -904,8 +904,8 @@ packages:
       '@sinonjs/commons': 3.0.0
     dev: true
 
-  /@swc/core-darwin-arm64/1.3.68:
-    resolution: {integrity: sha512-Z5pNxeuP2NxpOHTzDQkJs0wAPLnTlglZnR3WjObijwvdwT/kw1Y5EPDKM/BVSIeG40SPMkDLBbI0aj0qyXzrBA==}
+  /@swc/core-darwin-arm64/1.3.82:
+    resolution: {integrity: sha512-JfsyDW34gVKD3uE0OUpUqYvAD3yseEaicnFP6pB292THtLJb0IKBBnK50vV/RzEJtc1bR3g1kNfxo2PeurZTrA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
@@ -913,8 +913,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-darwin-x64/1.3.68:
-    resolution: {integrity: sha512-ZHl42g6yXhfX4PzAQ0BNvBXpt/OcbAHfubWRN6eXELK3fiNnxL7QBW1if7iizlq6iA+Mj1pwHyyUit1pz0+fgA==}
+  /@swc/core-darwin-x64/1.3.82:
+    resolution: {integrity: sha512-ogQWgNMq7qTpITjcP3dnzkFNj7bh6SwMr859GvtOTrE75H7L7jDWxESfH4f8foB/LGxBKiDNmxKhitCuAsZK4A==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
@@ -922,8 +922,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-arm-gnueabihf/1.3.68:
-    resolution: {integrity: sha512-Mk8f6KCOQ2CNAR4PtWajIjS6XKSSR7ZYDOCf1GXRxhS3qEyQH7V8elWvqWYqHcT4foO60NUmxA/NOM/dQrdO1A==}
+  /@swc/core-linux-arm-gnueabihf/1.3.82:
+    resolution: {integrity: sha512-7TMXG1lXlNhD0kUiEqs+YlGV4irAdBa2quuy+XI3oJf2fBK6dQfEq4xBy65B3khrorzQS3O0oDGQ+cmdpHExHA==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
@@ -931,8 +931,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-arm64-gnu/1.3.68:
-    resolution: {integrity: sha512-RhBllggh9t9sIxaRgRcGrVaS7fDk6KsIqR6b9+dwU5OyDr4ZyHWw1ZaH/1/HAebuXYhNBjoNUiRtca6lKRIPgQ==}
+  /@swc/core-linux-arm64-gnu/1.3.82:
+    resolution: {integrity: sha512-26JkOujbzcItPAmIbD5vHJxQVy5ihcSu3YHTKwope1h28sApZdtE7S3e2G3gsZRTIdsCQkXUtAQeqHxGWWR3pw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -940,8 +940,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-arm64-musl/1.3.68:
-    resolution: {integrity: sha512-8K3zjU+tFgn6yGDEeD343gkKaHU9dhz77NiVkI1VzwRaT/Ag5pwl5eMQ1yStm8koNFzn3zq6rGjHfI5g2yI5Wg==}
+  /@swc/core-linux-arm64-musl/1.3.82:
+    resolution: {integrity: sha512-8Izj9tuuMpoc3cqiPBRtwqpO1BZ/+sfZVsEhLxrbOFlcSb8LnKyMle1g3JMMUwI4EU75RGVIzZMn8A6GOKdJbA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -949,8 +949,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-x64-gnu/1.3.68:
-    resolution: {integrity: sha512-4xAnvsBOyeTL0AB8GWlRKDM/hsysJ5jr5qvdKKI3rZfJgnnxl/xSX6TJKPsJ8gygfUJ3BmfCbmUmEyeDZ3YPvA==}
+  /@swc/core-linux-x64-gnu/1.3.82:
+    resolution: {integrity: sha512-0GSrIBScQwTaPv46T2qB7XnDYxndRCpwH4HMjh6FN+I+lfPUhTSJKW8AonqrqT1TbpFIgvzQs7EnTsD7AnSCow==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -958,8 +958,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-x64-musl/1.3.68:
-    resolution: {integrity: sha512-RCpaBo1fcpy1EFdjF+I7N4lfzOaHXVV0iMw/ABM+0PD6tp3V/9pxsguaZyeAHyEiUlDA6PZ4TfXv5zfnXEgW4Q==}
+  /@swc/core-linux-x64-musl/1.3.82:
+    resolution: {integrity: sha512-KJUnaaepDKNzrEbwz4jv0iC3/t9x0NSoe06fnkAlhh2+NFKWKKJhVCOBTrpds8n7eylBDIXUlK34XQafjVMUdg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -967,8 +967,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-win32-arm64-msvc/1.3.68:
-    resolution: {integrity: sha512-v2WZvXrSslYEpY1nqpItyamL4DyaJinmOkXvM8Bc1LLKU5rGuvmBdjUYg/5Y+o0AUynuiWubpgHNOkBWiCvfqw==}
+  /@swc/core-win32-arm64-msvc/1.3.82:
+    resolution: {integrity: sha512-TR3MHKhDYIyGyFcyl2d/p1ftceXcubAhX5wRSOdtOyr5+K/v3jbyCCqN7bbqO5o43wQVCwwR/drHleYyDZvg8Q==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
@@ -976,8 +976,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-win32-ia32-msvc/1.3.68:
-    resolution: {integrity: sha512-HH5NJrIdzkJs+1xxprie0qSCMBeL9yeEhcC1yZTzYv8bwmabOUSdtKIqS55iYP/2hLWn9CTbvKPmLOIhCopW3Q==}
+  /@swc/core-win32-ia32-msvc/1.3.82:
+    resolution: {integrity: sha512-ZX4HzVVt6hs84YUg70UvyBJnBOIspmQQM0iXSzBvOikk3zRoN7BnDwQH4GScvevCEBuou60+i4I6d5kHLOfh8Q==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
@@ -985,8 +985,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-win32-x64-msvc/1.3.68:
-    resolution: {integrity: sha512-9HZVtLQUgK8r/yXQdwe0VBexbIcrY6+fBROhs7AAPWdewpaUeLkwQEJk6TbYr9CQuHw26FFGg6SjwAiqXF+kgQ==}
+  /@swc/core-win32-x64-msvc/1.3.82:
+    resolution: {integrity: sha512-4mJMnex21kbQoaHeAmHnVwQN9/XAfPszJ6n9HI7SVH+aAHnbBIR0M59/b50/CJMjTj5niUGk7EwQ3nhVNOG32g==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
@@ -994,8 +994,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core/1.3.68_@swc+helpers@0.5.1:
-    resolution: {integrity: sha512-njGQuJO+Wy06dEayt70cf0c/KI3HGjm4iW9LLViVLBuYNzJ4SSdNfzejludzufu6im+dsDJ0i3QjgWhAIcVHMQ==}
+  /@swc/core/1.3.82_@swc+helpers@0.5.1:
+    resolution: {integrity: sha512-jpC1a18HMH67018Ij2jh+hT7JBFu7ZKcQVfrZ8K6JuEY+kjXmbea07P9MbQUZbAe0FB+xi3CqEVCP73MebodJQ==}
     engines: {node: '>=10'}
     requiresBuild: true
     peerDependencies:
@@ -1005,17 +1005,18 @@ packages:
         optional: true
     dependencies:
       '@swc/helpers': 0.5.1
+      '@swc/types': 0.1.4
     optionalDependencies:
-      '@swc/core-darwin-arm64': 1.3.68
-      '@swc/core-darwin-x64': 1.3.68
-      '@swc/core-linux-arm-gnueabihf': 1.3.68
-      '@swc/core-linux-arm64-gnu': 1.3.68
-      '@swc/core-linux-arm64-musl': 1.3.68
-      '@swc/core-linux-x64-gnu': 1.3.68
-      '@swc/core-linux-x64-musl': 1.3.68
-      '@swc/core-win32-arm64-msvc': 1.3.68
-      '@swc/core-win32-ia32-msvc': 1.3.68
-      '@swc/core-win32-x64-msvc': 1.3.68
+      '@swc/core-darwin-arm64': 1.3.82
+      '@swc/core-darwin-x64': 1.3.82
+      '@swc/core-linux-arm-gnueabihf': 1.3.82
+      '@swc/core-linux-arm64-gnu': 1.3.82
+      '@swc/core-linux-arm64-musl': 1.3.82
+      '@swc/core-linux-x64-gnu': 1.3.82
+      '@swc/core-linux-x64-musl': 1.3.82
+      '@swc/core-win32-arm64-msvc': 1.3.82
+      '@swc/core-win32-ia32-msvc': 1.3.82
+      '@swc/core-win32-x64-msvc': 1.3.82
     dev: true
 
   /@swc/helpers/0.5.1:
@@ -1024,15 +1025,19 @@ packages:
       tslib: 2.5.3
     dev: true
 
-  /@swc/jest/0.2.26_@swc+core@1.3.68:
+  /@swc/jest/0.2.26_@swc+core@1.3.82:
     resolution: {integrity: sha512-7lAi7q7ShTO3E5Gt1Xqf3pIhRbERxR1DUxvtVa9WKzIB+HGQ7wZP5sYx86zqnaEoKKGhmOoZ7gyW0IRu8Br5+A==}
     engines: {npm: '>= 7.0.0'}
     peerDependencies:
       '@swc/core': '*'
     dependencies:
       '@jest/create-cache-key-function': 27.5.1
-      '@swc/core': 1.3.68_@swc+helpers@0.5.1
+      '@swc/core': 1.3.82_@swc+helpers@0.5.1
       jsonc-parser: 3.2.0
+    dev: true
+
+  /@swc/types/0.1.4:
+    resolution: {integrity: sha512-z/G02d+59gyyUb7KYhKi9jOhicek6QD2oMaotUyG+lUkybpXoV49dY9bj7Ah5Q+y7knK2jU67UTX9FyfGzaxQg==}
     dev: true
 
   /@types/babel__core/7.20.1:
@@ -1323,15 +1328,15 @@ packages:
       '@rollup/plugin-node-resolve': 15.0.2_rollup@3.20.7
       '@rollup/plugin-replace': 5.0.2_rollup@3.20.7
       '@rollup/plugin-wasm': 6.1.3_rollup@3.20.7
-      '@swc/core': 1.3.68_@swc+helpers@0.5.1
+      '@swc/core': 1.3.82_@swc+helpers@0.5.1
       '@swc/helpers': 0.5.1
       arg: 5.0.2
       pretty-bytes: 5.6.0
       publint: 0.1.16
       rollup: 3.20.7
       rollup-plugin-dts: 5.3.0_xjj3wbudmbebg277jo7il5ib7y
-      rollup-plugin-swc3: 0.8.2_z5crzbobybjr2452s4xz5dlq6i
-      rollup-swc-preserve-directives: 0.3.2_z5crzbobybjr2452s4xz5dlq6i
+      rollup-plugin-swc3: 0.8.2_uwjsx23hxuosdqu2kkre7rtzqq
+      rollup-swc-preserve-directives: 0.3.2_uwjsx23hxuosdqu2kkre7rtzqq
       tslib: 2.5.3
       typescript: 5.1.6
     dev: true
@@ -2574,7 +2579,7 @@ packages:
       '@babel/code-frame': 7.22.5
     dev: true
 
-  /rollup-plugin-swc3/0.8.2_z5crzbobybjr2452s4xz5dlq6i:
+  /rollup-plugin-swc3/0.8.2_uwjsx23hxuosdqu2kkre7rtzqq:
     resolution: {integrity: sha512-8C8rw7Iw3s+RvIooDu0IaXGQDijYFiDpKMuwQPxv3onwa/ysojz3BzG8Lr2AbhX6Hd/2UT2wkerFFwOWQ3ytOQ==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -2583,12 +2588,12 @@ packages:
     dependencies:
       '@fastify/deepmerge': 1.3.0
       '@rollup/pluginutils': 4.2.1
-      '@swc/core': 1.3.68_@swc+helpers@0.5.1
+      '@swc/core': 1.3.82_@swc+helpers@0.5.1
       get-tsconfig: 4.6.2
       rollup: 3.20.7
     dev: true
 
-  /rollup-plugin-swc3/0.9.0_lvywkpsbewqmirs3gigiq5kd2q:
+  /rollup-plugin-swc3/0.9.0_iw3jk5lyrkr3mh5xkkw6sbmnnu:
     resolution: {integrity: sha512-b5OjzeD9F5H6hmtHqI6GJkPiJPyUrIu9cjvvjv4OOMW79nukmmd8QJLqrVxsJk7Y3vZXOzOgBSzKLkCM/Jt5Vw==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -2598,19 +2603,19 @@ packages:
       '@fastify/deepmerge': 1.3.0
       '@napi-rs/magic-string': 0.3.4
       '@rollup/pluginutils': 4.2.1
-      '@swc/core': 1.3.68_@swc+helpers@0.5.1
+      '@swc/core': 1.3.82_@swc+helpers@0.5.1
       get-tsconfig: 4.6.2
       rollup: 3.26.2
     dev: true
 
-  /rollup-swc-preserve-directives/0.3.2_z5crzbobybjr2452s4xz5dlq6i:
+  /rollup-swc-preserve-directives/0.3.2_uwjsx23hxuosdqu2kkre7rtzqq:
     resolution: {integrity: sha512-W0zljPCOMFErWUweRvnN9LCNrII2KzjAw9iZUNM1kZdf3rwQGQQiaCPnH4ugu3UIj1b+zEJKee20S8Ozgwh8Wg==}
     peerDependencies:
       '@swc/core': '>=1.2.165'
       rollup: ^2.0.0 || ^3.0.0
     dependencies:
       '@napi-rs/magic-string': 0.3.4
-      '@swc/core': 1.3.68_@swc+helpers@0.5.1
+      '@swc/core': 1.3.82_@swc+helpers@0.5.1
       rollup: 3.20.7
     dev: true
 

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -3,12 +3,6 @@
 exports[`preserve-directive (rollup 2) issue #9 1`] = `
 {
   "index": "'use strict';
-/**
- * Copyright (c) 2013-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */ 
 function emptyFunction() {}
 function emptyFunctionWithReset() {}
 emptyFunctionWithReset.resetWarningCache = emptyFunction;
@@ -122,12 +116,6 @@ console.log('shebang');
 exports[`preserve-directive (rollup 3) issue #9 1`] = `
 {
   "index": "'use strict';
-/**
- * Copyright (c) 2013-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */ 
 function emptyFunction() {}
 function emptyFunctionWithReset() {}
 emptyFunctionWithReset.resetWarningCache = emptyFunction;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,10 +2,11 @@ import { tester } from './testing-utils';
 import { rollup as rollup3 } from 'rollup';
 import { rollup as rollup2 } from 'rollup2';
 
-const tests = (rollupImpl: typeof rollup3) => {
+const runTests = (rollupImpl: typeof rollup3, version: number) => {
   it('should preserve shebang', async () => {
     const output = await tester(rollupImpl, {
-      input: 'shebang/index.ts'
+      input: 'shebang/index.ts',
+      version,
     });
 
     expect(output).toMatchSnapshot();
@@ -48,10 +49,10 @@ const tests = (rollupImpl: typeof rollup3) => {
 }
 
 describe('preserve-directive (rollup 3)', () => {
-  tests(rollup3);
+  runTests(rollup3, 3);
 });
 
 describe('preserve-directive (rollup 2)', () => {
-  // @ts-expect-error -- rollup 2 type is imcompatible w/ rollup 3
-  tests(rollup2);
+  // @ts-expect-error -- rollup 2 type is incompatible w/ rollup 3
+  runTests(rollup2, 2);
 });


### PR DESCRIPTION
x-ref: https://github.com/huozhi/rollup-plugin-swc-preserve-directives/pull/4#issuecomment-1706551223

* Add `@swc/core` back
* Remove code deleting logic
* Use `onLog` to skip unknown directives warning (only for rollup 3)