### PR TITLE
refactor: re-implement rollup built-in parse API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@ A rollup plugin helps preserving shebang and string directives in your code.
 
 ```bash
 npm install rollup-swc-preserve-directives
-
-# You also need to install @swc/core as peer dependency
-npm install @swc/core
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -30,14 +30,13 @@
   "author": "huozhi",
   "license": "MIT",
   "peerDependencies": {
-    "@swc/core": ">=1.3.79",
     "rollup": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "dependencies": {
     "@napi-rs/magic-string": "^0.3.4"
   },
   "devDependencies": {
-    "@swc/core": "^1.3.82",
+    "@swc/core": "^1.3.96",
     "@swc/helpers": "^0.5.1",
     "@swc/jest": "^0.2.26",
     "@types/estree": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@napi-rs/magic-string': ^0.3.4
-  '@swc/core': ^1.3.82
+  '@swc/core': ^1.3.96
   '@swc/helpers': ^0.5.1
   '@swc/jest': ^0.2.26
   '@types/estree': ^1.0.1
@@ -21,9 +21,9 @@ dependencies:
   '@napi-rs/magic-string': 0.3.4
 
 devDependencies:
-  '@swc/core': 1.3.82_@swc+helpers@0.5.1
+  '@swc/core': 1.3.96_@swc+helpers@0.5.1
   '@swc/helpers': 0.5.1
-  '@swc/jest': 0.2.26_@swc+core@1.3.82
+  '@swc/jest': 0.2.26_@swc+core@1.3.96
   '@types/estree': 1.0.1
   '@types/jest': 29.5.2
   '@types/node': 20.4.1
@@ -31,7 +31,7 @@ devDependencies:
   bunchee: 3.6.1_typescript@5.1.6
   jest: 29.6.1_@types+node@20.4.1
   rollup: 3.28.1
-  rollup-plugin-swc3: 0.9.0_ayu62oiofpgomvef3ep6kxzqem
+  rollup-plugin-swc3: 0.9.0_4dg5ewbtivth5d4umte3zzhlei
   rollup2: /rollup/2.79.1
   rollup4: /rollup/4.4.1
   typescript: 5.1.6
@@ -1002,8 +1002,8 @@ packages:
       '@sinonjs/commons': 3.0.0
     dev: true
 
-  /@swc/core-darwin-arm64/1.3.82:
-    resolution: {integrity: sha512-JfsyDW34gVKD3uE0OUpUqYvAD3yseEaicnFP6pB292THtLJb0IKBBnK50vV/RzEJtc1bR3g1kNfxo2PeurZTrA==}
+  /@swc/core-darwin-arm64/1.3.96:
+    resolution: {integrity: sha512-8hzgXYVd85hfPh6mJ9yrG26rhgzCmcLO0h1TIl8U31hwmTbfZLzRitFQ/kqMJNbIBCwmNH1RU2QcJnL3d7f69A==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
@@ -1011,8 +1011,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-darwin-x64/1.3.82:
-    resolution: {integrity: sha512-ogQWgNMq7qTpITjcP3dnzkFNj7bh6SwMr859GvtOTrE75H7L7jDWxESfH4f8foB/LGxBKiDNmxKhitCuAsZK4A==}
+  /@swc/core-darwin-x64/1.3.96:
+    resolution: {integrity: sha512-mFp9GFfuPg+43vlAdQZl0WZpZSE8sEzqL7sr/7Reul5McUHP0BaLsEzwjvD035ESfkY8GBZdLpMinblIbFNljQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
@@ -1020,8 +1020,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-arm-gnueabihf/1.3.82:
-    resolution: {integrity: sha512-7TMXG1lXlNhD0kUiEqs+YlGV4irAdBa2quuy+XI3oJf2fBK6dQfEq4xBy65B3khrorzQS3O0oDGQ+cmdpHExHA==}
+  /@swc/core-linux-arm-gnueabihf/1.3.96:
+    resolution: {integrity: sha512-8UEKkYJP4c8YzYIY/LlbSo8z5Obj4hqcv/fUTHiEePiGsOddgGf7AWjh56u7IoN/0uEmEro59nc1ChFXqXSGyg==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
@@ -1029,8 +1029,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-arm64-gnu/1.3.82:
-    resolution: {integrity: sha512-26JkOujbzcItPAmIbD5vHJxQVy5ihcSu3YHTKwope1h28sApZdtE7S3e2G3gsZRTIdsCQkXUtAQeqHxGWWR3pw==}
+  /@swc/core-linux-arm64-gnu/1.3.96:
+    resolution: {integrity: sha512-c/IiJ0s1y3Ymm2BTpyC/xr6gOvoqAVETrivVXHq68xgNms95luSpbYQ28rqaZC8bQC8M5zdXpSc0T8DJu8RJGw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -1038,8 +1038,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-arm64-musl/1.3.82:
-    resolution: {integrity: sha512-8Izj9tuuMpoc3cqiPBRtwqpO1BZ/+sfZVsEhLxrbOFlcSb8LnKyMle1g3JMMUwI4EU75RGVIzZMn8A6GOKdJbA==}
+  /@swc/core-linux-arm64-musl/1.3.96:
+    resolution: {integrity: sha512-i5/UTUwmJLri7zhtF6SAo/4QDQJDH2fhYJaBIUhrICmIkRO/ltURmpejqxsM/ye9Jqv5zG7VszMC0v/GYn/7BQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -1047,8 +1047,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-x64-gnu/1.3.82:
-    resolution: {integrity: sha512-0GSrIBScQwTaPv46T2qB7XnDYxndRCpwH4HMjh6FN+I+lfPUhTSJKW8AonqrqT1TbpFIgvzQs7EnTsD7AnSCow==}
+  /@swc/core-linux-x64-gnu/1.3.96:
+    resolution: {integrity: sha512-USdaZu8lTIkm4Yf9cogct/j5eqtdZqTgcTib4I+NloUW0E/hySou3eSyp3V2UAA1qyuC72ld1otXuyKBna0YKQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -1056,8 +1056,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-x64-musl/1.3.82:
-    resolution: {integrity: sha512-KJUnaaepDKNzrEbwz4jv0iC3/t9x0NSoe06fnkAlhh2+NFKWKKJhVCOBTrpds8n7eylBDIXUlK34XQafjVMUdg==}
+  /@swc/core-linux-x64-musl/1.3.96:
+    resolution: {integrity: sha512-QYErutd+G2SNaCinUVobfL7jWWjGTI0QEoQ6hqTp7PxCJS/dmKmj3C5ZkvxRYcq7XcZt7ovrYCTwPTHzt6lZBg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -1065,8 +1065,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-win32-arm64-msvc/1.3.82:
-    resolution: {integrity: sha512-TR3MHKhDYIyGyFcyl2d/p1ftceXcubAhX5wRSOdtOyr5+K/v3jbyCCqN7bbqO5o43wQVCwwR/drHleYyDZvg8Q==}
+  /@swc/core-win32-arm64-msvc/1.3.96:
+    resolution: {integrity: sha512-hjGvvAduA3Un2cZ9iNP4xvTXOO4jL3G9iakhFsgVhpkU73SGmK7+LN8ZVBEu4oq2SUcHO6caWvnZ881cxGuSpg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
@@ -1074,8 +1074,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-win32-ia32-msvc/1.3.82:
-    resolution: {integrity: sha512-ZX4HzVVt6hs84YUg70UvyBJnBOIspmQQM0iXSzBvOikk3zRoN7BnDwQH4GScvevCEBuou60+i4I6d5kHLOfh8Q==}
+  /@swc/core-win32-ia32-msvc/1.3.96:
+    resolution: {integrity: sha512-Far2hVFiwr+7VPCM2GxSmbh3ikTpM3pDombE+d69hkedvYHYZxtTF+2LTKl/sXtpbUnsoq7yV/32c9R/xaaWfw==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
@@ -1083,8 +1083,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-win32-x64-msvc/1.3.82:
-    resolution: {integrity: sha512-4mJMnex21kbQoaHeAmHnVwQN9/XAfPszJ6n9HI7SVH+aAHnbBIR0M59/b50/CJMjTj5niUGk7EwQ3nhVNOG32g==}
+  /@swc/core-win32-x64-msvc/1.3.96:
+    resolution: {integrity: sha512-4VbSAniIu0ikLf5mBX81FsljnfqjoVGleEkCQv4+zRlyZtO3FHoDPkeLVoy6WRlj7tyrRcfUJ4mDdPkbfTO14g==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
@@ -1092,8 +1092,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core/1.3.82_@swc+helpers@0.5.1:
-    resolution: {integrity: sha512-jpC1a18HMH67018Ij2jh+hT7JBFu7ZKcQVfrZ8K6JuEY+kjXmbea07P9MbQUZbAe0FB+xi3CqEVCP73MebodJQ==}
+  /@swc/core/1.3.96_@swc+helpers@0.5.1:
+    resolution: {integrity: sha512-zwE3TLgoZwJfQygdv2SdCK9mRLYluwDOM53I+dT6Z5ZvrgVENmY3txvWDvduzkV+/8IuvrRbVezMpxcojadRdQ==}
     engines: {node: '>=10'}
     requiresBuild: true
     peerDependencies:
@@ -1102,19 +1102,24 @@ packages:
       '@swc/helpers':
         optional: true
     dependencies:
+      '@swc/counter': 0.1.2
       '@swc/helpers': 0.5.1
-      '@swc/types': 0.1.4
+      '@swc/types': 0.1.5
     optionalDependencies:
-      '@swc/core-darwin-arm64': 1.3.82
-      '@swc/core-darwin-x64': 1.3.82
-      '@swc/core-linux-arm-gnueabihf': 1.3.82
-      '@swc/core-linux-arm64-gnu': 1.3.82
-      '@swc/core-linux-arm64-musl': 1.3.82
-      '@swc/core-linux-x64-gnu': 1.3.82
-      '@swc/core-linux-x64-musl': 1.3.82
-      '@swc/core-win32-arm64-msvc': 1.3.82
-      '@swc/core-win32-ia32-msvc': 1.3.82
-      '@swc/core-win32-x64-msvc': 1.3.82
+      '@swc/core-darwin-arm64': 1.3.96
+      '@swc/core-darwin-x64': 1.3.96
+      '@swc/core-linux-arm-gnueabihf': 1.3.96
+      '@swc/core-linux-arm64-gnu': 1.3.96
+      '@swc/core-linux-arm64-musl': 1.3.96
+      '@swc/core-linux-x64-gnu': 1.3.96
+      '@swc/core-linux-x64-musl': 1.3.96
+      '@swc/core-win32-arm64-msvc': 1.3.96
+      '@swc/core-win32-ia32-msvc': 1.3.96
+      '@swc/core-win32-x64-msvc': 1.3.96
+    dev: true
+
+  /@swc/counter/0.1.2:
+    resolution: {integrity: sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw==}
     dev: true
 
   /@swc/helpers/0.5.1:
@@ -1123,19 +1128,19 @@ packages:
       tslib: 2.5.3
     dev: true
 
-  /@swc/jest/0.2.26_@swc+core@1.3.82:
+  /@swc/jest/0.2.26_@swc+core@1.3.96:
     resolution: {integrity: sha512-7lAi7q7ShTO3E5Gt1Xqf3pIhRbERxR1DUxvtVa9WKzIB+HGQ7wZP5sYx86zqnaEoKKGhmOoZ7gyW0IRu8Br5+A==}
     engines: {npm: '>= 7.0.0'}
     peerDependencies:
       '@swc/core': '*'
     dependencies:
       '@jest/create-cache-key-function': 27.5.1
-      '@swc/core': 1.3.82_@swc+helpers@0.5.1
+      '@swc/core': 1.3.96_@swc+helpers@0.5.1
       jsonc-parser: 3.2.0
     dev: true
 
-  /@swc/types/0.1.4:
-    resolution: {integrity: sha512-z/G02d+59gyyUb7KYhKi9jOhicek6QD2oMaotUyG+lUkybpXoV49dY9bj7Ah5Q+y7knK2jU67UTX9FyfGzaxQg==}
+  /@swc/types/0.1.5:
+    resolution: {integrity: sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==}
     dev: true
 
   /@types/babel__core/7.20.1:
@@ -1426,15 +1431,15 @@ packages:
       '@rollup/plugin-node-resolve': 15.0.2_rollup@3.20.7
       '@rollup/plugin-replace': 5.0.2_rollup@3.20.7
       '@rollup/plugin-wasm': 6.1.3_rollup@3.20.7
-      '@swc/core': 1.3.82_@swc+helpers@0.5.1
+      '@swc/core': 1.3.96_@swc+helpers@0.5.1
       '@swc/helpers': 0.5.1
       arg: 5.0.2
       pretty-bytes: 5.6.0
       publint: 0.1.16
       rollup: 3.20.7
       rollup-plugin-dts: 5.3.0_xjj3wbudmbebg277jo7il5ib7y
-      rollup-plugin-swc3: 0.8.2_uwjsx23hxuosdqu2kkre7rtzqq
-      rollup-swc-preserve-directives: 0.3.2_uwjsx23hxuosdqu2kkre7rtzqq
+      rollup-plugin-swc3: 0.8.2_kc7qfpmgjxyhpdagillm62m3ge
+      rollup-swc-preserve-directives: 0.3.2_kc7qfpmgjxyhpdagillm62m3ge
       tslib: 2.5.3
       typescript: 5.1.6
     dev: true
@@ -2677,7 +2682,7 @@ packages:
       '@babel/code-frame': 7.22.5
     dev: true
 
-  /rollup-plugin-swc3/0.8.2_uwjsx23hxuosdqu2kkre7rtzqq:
+  /rollup-plugin-swc3/0.8.2_kc7qfpmgjxyhpdagillm62m3ge:
     resolution: {integrity: sha512-8C8rw7Iw3s+RvIooDu0IaXGQDijYFiDpKMuwQPxv3onwa/ysojz3BzG8Lr2AbhX6Hd/2UT2wkerFFwOWQ3ytOQ==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -2686,12 +2691,12 @@ packages:
     dependencies:
       '@fastify/deepmerge': 1.3.0
       '@rollup/pluginutils': 4.2.1
-      '@swc/core': 1.3.82_@swc+helpers@0.5.1
+      '@swc/core': 1.3.96_@swc+helpers@0.5.1
       get-tsconfig: 4.6.2
       rollup: 3.20.7
     dev: true
 
-  /rollup-plugin-swc3/0.9.0_ayu62oiofpgomvef3ep6kxzqem:
+  /rollup-plugin-swc3/0.9.0_4dg5ewbtivth5d4umte3zzhlei:
     resolution: {integrity: sha512-b5OjzeD9F5H6hmtHqI6GJkPiJPyUrIu9cjvvjv4OOMW79nukmmd8QJLqrVxsJk7Y3vZXOzOgBSzKLkCM/Jt5Vw==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -2701,19 +2706,19 @@ packages:
       '@fastify/deepmerge': 1.3.0
       '@napi-rs/magic-string': 0.3.4
       '@rollup/pluginutils': 4.2.1
-      '@swc/core': 1.3.82_@swc+helpers@0.5.1
+      '@swc/core': 1.3.96_@swc+helpers@0.5.1
       get-tsconfig: 4.6.2
       rollup: 3.28.1
     dev: true
 
-  /rollup-swc-preserve-directives/0.3.2_uwjsx23hxuosdqu2kkre7rtzqq:
+  /rollup-swc-preserve-directives/0.3.2_kc7qfpmgjxyhpdagillm62m3ge:
     resolution: {integrity: sha512-W0zljPCOMFErWUweRvnN9LCNrII2KzjAw9iZUNM1kZdf3rwQGQQiaCPnH4ugu3UIj1b+zEJKee20S8Ozgwh8Wg==}
     peerDependencies:
       '@swc/core': '>=1.2.165'
       rollup: ^2.0.0 || ^3.0.0
     dependencies:
       '@napi-rs/magic-string': 0.3.4
-      '@swc/core': 1.3.82_@swc+helpers@0.5.1
+      '@swc/core': 1.3.96_@swc+helpers@0.5.1
       rollup: 3.20.7
     dev: true
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,10 @@
 import type { Plugin, RenderedChunk } from 'rollup'
 import { extname } from 'path'
-import { parse } from '@swc/core'
 import { MagicString } from '@napi-rs/magic-string'
 
-import type { ParseOptions } from '@swc/core';
+import type { Node } from 'estree';
 
 const availableESExtensionsRegex = /\.(m|c)?(j|t)sx?$/
-const tsExtensionsRegex = /\.(m|c)?tsx?$/
 const directiveRegex = /^use (\w+)$/
 
 interface PreserveDirectiveMeta {
@@ -22,50 +20,111 @@ function swcPreserveDirective(): Plugin {
 
   return {
     name: 'swc-render-directive',
-    async transform(code, id) {
-      const ext = extname(id)
-      if (!availableESExtensionsRegex.test(ext)) return code
-
-      const isTypescript = tsExtensionsRegex.test(ext)
-      const parseOptions: ParseOptions = {
-        syntax: isTypescript ? 'typescript' : 'ecmascript',
-        [isTypescript ? 'tsx' : 'jsx']: true,
-        privateMethod: true,
-        classPrivateProperty: true,
-        exportDefaultFrom: true,
-        script: false, target: 'es2019'
-      } as const
-
-      let magicString: MagicString | null = null
-
-      /**
-       * @swc/core's node span doesn't start with 0
-       * https://github.com/swc-project/swc/issues/1366
-       */
-      const { body, interpreter } = await parse(code, parseOptions)
-
-      if (interpreter) {
-        meta.shebang = `#!${interpreter}`
-        code = code.replace(new RegExp('^[\\s\\n]*' + meta.shebang.replace(/\//g, '\/') + '\\n*'), '') // Remove shebang from code
-      }
-
-      for (const node of body) {
-        if (node.type === 'ExpressionStatement') {
-          if (node.expression.type === 'StringLiteral' && directiveRegex.test(node.expression.value)) {
-            meta.directives[id] ||= new Set<string>();
-            meta.directives[id].add(node.expression.value);
-
-            magicString ||= new MagicString(code)
-          }
-        } else {
-          // Only parse the top level directives, once reached to the first non statement literal node, stop parsing
-          break
+    transform: {
+      order: 'post',
+      handler(code, id) {
+        const ext = extname(id)
+        if (!availableESExtensionsRegex.test(ext)) {
+          return null;
         }
-      }
 
-      return {
-        code: magicString ? magicString.toString() : code,
-        map: magicString ? magicString.generateMap({ hires: true }).toMap() : null
+        const magicString: MagicString = new MagicString(code);
+
+        /**
+         * Here we are making 3 assumptions:
+         * - shebang can only be at the first line of the file, otherwise it will not be recognized
+         * - shebang can only contains one line
+         * - shebang must starts with # and !
+         *
+         * Those assumptions are also made by acorn, babel and swc:
+         *
+         * - acorn: https://github.com/acornjs/acorn/blob/8da1fdd1918c9a9a5748501017262ce18bb2f2cc/acorn/src/state.js#L78
+         * - babel: https://github.com/babel/babel/blob/86fee43f499c76388cab495c8dcc4e821174d4e0/packages/babel-parser/src/tokenizer/index.ts#L574
+         * - swc: https://github.com/swc-project/swc/blob/7bf4ab39b0e49759d9f5c8d7f989b3ed010d81a7/crates/swc_ecma_parser/src/lexer/mod.rs#L204
+         */
+        if (code[0] === '#' && code[1] === '!') {
+          let firstNewLineIndex = 0;
+
+          for (let i = 2, len = code.length; i < len; i++) {
+            const charCode = code.charCodeAt(i);
+            if (charCode === 10 || charCode === 13 || charCode === 0x2028 || charCode === 0x2029) {
+              firstNewLineIndex = i;
+              break;
+            }
+          }
+
+          if (firstNewLineIndex) {
+            meta.shebang = code.slice(0, firstNewLineIndex);
+
+            magicString.remove(0, firstNewLineIndex + 1);
+          }
+        }
+
+        /**
+         * rollup's built-in parser returns an extended version of ESTree Node.
+         */
+        let ast: null | Node = null;
+        try {
+          ast = this.parse(magicString.toString(), { allowReturnOutsideFunction: true, allowShebang: true }) as Node;
+        } catch (e) {
+          this.warn({
+            code: 'PARSE_ERROR',
+            message: `[rollup-swc-preserve-directives]: failed to parse "${id}" and extract the directives. make sure you have added "rollup-swc-preserve-directives" to the last of your plugins list, after swc/babel/esbuild/typescript or any other transform plugins.`
+          });
+
+          console.warn(e);
+
+          return null;
+        }
+
+        // Exit if the root of the AST is not a Program
+        if (ast.type !== 'Program') {
+          return null;
+        }
+
+        for (const node of ast.body) {
+          // Only parse the top level directives, once reached to the first non statement literal node, stop parsing
+          if (node.type !== 'ExpressionStatement') {
+            break;
+          }
+
+          let directive: string | null = null;
+          /**
+           * rollup and estree defines `directive` field on the `ExpressionStatement` node:
+           * https://github.com/rollup/rollup/blob/fecf0cfe14a9d79bb0eff4ad475174ce72775ead/src/ast/nodes/ExpressionStatement.ts#L10
+           */
+          if ('directive' in node) {
+            directive = node.directive;
+          } else if (node.expression.type === 'Literal' && typeof node.expression.value === 'string' && directiveRegex.test(node.expression.value)) {
+            directive = node.expression.value;
+          }
+
+          if (directive) {
+            meta.directives[id] ||= new Set<string>();
+            meta.directives[id].add(directive);
+
+            /**
+             * rollup has extended acorn node with the `start` and the `end` field
+             * https://github.com/rollup/rollup/blob/fecf0cfe14a9d79bb0eff4ad475174ce72775ead/src/ast/nodes/shared/Node.ts#L33
+             *
+             * However, typescript doesn't know that, so we add type guards for typescript
+             * to infer.
+             */
+            if (
+              'start' in node
+              && typeof node.start === 'number'
+              && 'end' in node
+              && typeof node.end === 'number'
+            ) {
+              magicString.remove(node.start, node.end);
+            }
+          }
+        }
+
+        return {
+          code: magicString ? magicString.toString() : code,
+          map: magicString ? magicString.generateMap({ hires: true }).toMap() : null
+        }
       }
     },
 

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -3,6 +3,12 @@
 exports[`preserve-directive (rollup 2) issue #9 1`] = `
 {
   "index": "'use strict';
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */ 
 function emptyFunction() {}
 function emptyFunctionWithReset() {}
 emptyFunctionWithReset.resetWarningCache = emptyFunction;
@@ -116,6 +122,12 @@ console.log('shebang');
 exports[`preserve-directive (rollup 3) issue #9 1`] = `
 {
   "index": "'use strict';
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */ 
 function emptyFunction() {}
 function emptyFunctionWithReset() {}
 emptyFunctionWithReset.resetWarningCache = emptyFunction;
@@ -229,6 +241,12 @@ console.log('shebang');
 exports[`preserve-directive (rollup 4) issue #9 1`] = `
 {
   "index": "'use strict';
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */ 
 function emptyFunction() {}
 function emptyFunctionWithReset() {}
 emptyFunctionWithReset.resetWarningCache = emptyFunction;


### PR DESCRIPTION
Re-land rollup parse API.

> The reason that keeps breaking is we're using a pretty unsafe operation to delete code based on swc node's span as it's already not recommended, which is only for getting rid of the roll warnings.

Since we are using rollup's built-in `parse` API, the node span is now safe and correct.

I will also send another PR to `bunchee` to fix https://github.com/huozhi/rollup-plugin-swc-preserve-directives/pull/4#issuecomment-1706551223.